### PR TITLE
Correct Control & Checksum bytes

### DIFF
--- a/src/libs/ipac.c
+++ b/src/libs/ipac.c
@@ -426,8 +426,10 @@ void updatePre2015IPAC2Board (json_object *jobj, unsigned char* barray)
   unsigned char header[4] = {0x50, 0xdd, 0x00, 0x00};
   memcpy (barray, &header, sizeof(header));
 
+  /* Checksum data - Redundant? */
+  barray[65] = 0x00;
   /* Control data */
-  barray[65] = 0x29;
+  barray[66] = 0x00;
 
   json_object_object_get_ex(jobj, "1/2 shift key", &shiftKey);
   barray[4] = convertIPAC(shiftKey);


### PR DESCRIPTION
Control byte was actually setting Checksum byte (Used in early 2011 ipac cards).
Moved control byte to barray[66]
Created checksum byte at barray[65]

Zeroed both.