### PR TITLE
Support multiple Pac-Drive devices.

### DIFF
--- a/src/libs/common.h
+++ b/src/libs/common.h
@@ -36,6 +36,22 @@ struct libusb_device_handle* openUSB(libusb_context *ctx,
                                       int autoconnect);
 
 /**
+ * Will attempt to open the USB product and claim the interface specified.
+ * Finds the device by combination of vendor, product, and device release number.
+ * releaseNumber is in binary-coded decimal.
+ * If successful ctx variable will be populated and the return handle will be populated,
+ * otherwise they will be NULL;
+ * interface = -1 the calling function will need to claim the interface this function will not
+ * autoconnect = 1 the kernel driver will be attached after we are done with the device
+ */
+struct libusb_device_handle* openUSBWithReleaseNumber(libusb_context *ctx,
+                                                      uint16_t vendor,
+                                                      uint16_t product,
+                                                      uint16_t releaseNumber,
+                                                      int interface,
+                                                      int autoconnect);
+
+/**
  * Attempt to claim the interface
  * autoconnect = 1 the kernel driver will be attached after we are done with the device
  */

--- a/src/libs/pacdrive.c
+++ b/src/libs/pacdrive.c
@@ -99,7 +99,6 @@ bool updateBoardPacDrive (json_object *jobj)
   int map2 = 0;
   int map3 = 0;
   int total = 0;
-  uint16_t product = PACDRIVE_PRODUCT;
 
   char map[PACDRIVE_DATA_SIZE] = {0,0,0,0};
 
@@ -111,9 +110,8 @@ bool updateBoardPacDrive (json_object *jobj)
 
   json_object_object_get_ex(jobj, "board id", &tmp);
   board = json_object_get_int(tmp);
-  product += (board - 1);
 
-  handle = openUSB(ctx, PACDRIVE_VENDOR, product, PACDRIVE_INTERFACE, 0);
+  handle = openUSBWithReleaseNumber(ctx, PACDRIVE_VENDOR, PACDRIVE_PRODUCT, board, PACDRIVE_INTERFACE, 0);
 
   if (!handle)
   {


### PR DESCRIPTION
Updates umtool to support multiple Pac-Drive boards, fixes issue #48 .  The Pac-Drive boards must have been ordered from Ultimarc with unique IDs.  All Pac-Drive boards use 0x1500 as the Product ID, the device release number (bcdDevice) of the USB device is what indicates the board ID (according to the Windows Pac-Drive SDK code on the Ultimarc website, though that code calls the field "Version Number" instead of "Device Release Number").  A new function named "openUSBWithReleaseNumber" has been added to common.c that traverses the USB device list and opens the device with the matching vendor/product/release number combination.  The pacdrive.c code has been updated to use this function for opening the device.  These changes have been tested with board IDs 1 and 2 but should work for 3 and 4 as well.  