### PR TITLE
Update README.md

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,5 +4,65 @@ NEXT.VERSION
   * Added type, range and almost all data validation for the supported boards
   * Added IPAC Ultimate and PAC Drive board support
 
-0.1
-  * initial release
+
+V1.2.0 <DATE>
+-------------
+1.2.0 Release
+
+Add paclink configuration, Correct 2015 ipac2 config byte, Fix disable shift function
+Support multiple Pac-Drive devices, Updated Aimtrak script: added AdvMame support
+Added ultistik 360 configs, Add functionality for USBButtonConfigureColor SDK function.
+And other various fixes.
+
+
+V1.1.0 20 Jan 2017
+------------------
+U-HID Support
+
+This release adds U-HID and U-HID Nano board support to the Ultimarc-linux tools.
+This release also adds Macro support to the Ultimate I/O board.
+Also does some clean up of unused code in the ipacseries.c file.
+
+
+
+V1.0.0 04 Nov 2016
+------------------
+Additional Board support and API change
+
+This release will include support for the USB Button.
+
+The library API is changed for this release.
+The name of the umtool excutable will be changed, dropping the .out extension.
+
+
+V0.2.0 22 Apr 2016
+------------------
+0.2.0 Release
+
+In this release the following boards are supported;
+PACDrive, IPAC Ultimate, I-Pac 2, I-Pac 4, Mini-Pac, JPAC, UltraStik 360 and PacLED64
+
+There is support for pre2015 PAC boards and the current 2015 boards listed above.
+
+
+V0.1.0 18 Apr 2014
+------------------
+Inital release
+
+This is the initial release of the Ultimarc command line utility.
+
+The initial functionality allows for configuring the following devices from Ultimarc
+I-Pac 2
+I-Pac 4
+Mini-Pac
+UltraStik 360
+PacLED64
+
+This release also includes the ability to change the device ID for the UltraStik 360.
+
+Examples of how to configure each device is in the src/umtool directory.
+
+Not included in this release
+Ability to change the device ID for the PacLED64
+Robust file validation and boundary checking
+Robust debugging capability

--- a/NEWS
+++ b/NEWS
@@ -1,1 +1,2 @@
-Sample NEWS file for Ultimarc-linux project.
+No news is good news.
+Without information to the contrary you can assume that all is well.

--- a/README.fw
+++ b/README.fw
@@ -1,0 +1,60 @@
+Post 2015 IPAC2 Firmware features
+---------------------------------
+
+Single firmware
+    V1.22 - V1.33 Keyboard only support (Single Mode)
+Split firmwares
+    V1.34 - V1.39 Keyboard WITH Gamepad (Mixed Mode)
+    V1.44 - V1.49 Keyboard WITHOUT Gamepad (Single Mode)
+Split firmwares
+    V1.34 - V1.39 Keyboard WITH Gamepad (Mixed Mode)
+    V1.50 - V1.55 Keyboard SWITCH Gamepad (Multi Mode)
+
+Currently there are 2 WinIPAC2 programs to use depending on firmware.
+    Multi mode firmware requires the current version of WinIPAC2 v1.36.00
+    Mixed mode firmware requires the special version of WinIPAC2 v1.08.12
+    Single mode firmware should work with WinIPAC2 v1.08.12
+    
+History
+-------
+1.22 Cures intermittent failure to send keycodes on some hosts.
+1.23 Correct stuck shift on I-PAC 4.
+	Extend Start1 pulse time.
+	Following customer feedback this version reverts the self-test LED function to that of pre-2015 boards.
+	The LED is ON when no error detected.
+1.30 Correct false self-test failures (flashing LED at power on).
+1.31 Correct various PacLink issues
+1.32 Improved performance, reduce debounce timer value.
+1.33 Remove scan of unused connections
+1.34 Split version of game controller/no game controller support.
+1.35 (UIO only) shift key pulse too long when LEDs active.
+1.36 Gamepad-enabled firmware now appears as TWO gamepads.
+1.37 (UIO only) Lockup during LED animations
+1.38 Add variable de-bounce delay, selectable with 4 values in WinIPAC
+1.39 Harmonize all versions, no functional changes.
+
+Firmware with/without the Game Controller device
+------------------------------------------------
+Starting with version 34 there are separate firmware versions which have the game controller device present/not present.
+
+ Versions without game controller (ie with keyboard and mouse support) have the first version digit as "4" eg 1.44.
+ Versions with game controller (ie with gamepad button, keyboard and mouse support) have the first version digit as "3" eg 1.34.
+
+When changing versions it is necessary after the firmware change to locate the "composite device" under the USB Controllers
+entry in Device Manager and "Uninstall" this so that Windows can re-detect the new version correctly.
+
+Firmware (MultiMode)
+--------------------
+New boards are shipped with this version.
+Latest firmware files (ver 1.55) for all 2015-onwards I-PAC, Mini-PAC and J-PAC boards plus all Ultimate I/O boards regardless of date.
+
+All firmware except J-PAC now supports the Multi-Mode operation which enables switching to dual game controller mode or dual X-Input mode. Check the Multi-Mode tab on the product pages for more info.
+Before upgrading ensure you have the I-PAC shift functionality enabled otherwise mode switching will not work. The default is Start1 being the shift control.
+Also before upgrading to multi-mode firmware ensure the latest WinIPAC version is installed from the download page.
+If the board comes up in Xinput mode after upgrading, this can be reset to standard keyboard by holding P1SW1 while connecting USB cable. See the Multi-Mode product tab on the I-PAC pages for full details.
+
+Alternative Firmware (Mixed Mode)
+---------------------------------
+This is an alternative firmware version which enables the board to appear as a keyboard and dual standard game controller AT THE SAME TIME (both also with mouse). Note Retropie does not work with this configuration. The standard multiMode version (above) enables one device type at a time on the host (plus mouse) and this is required for Retropie. IMPORTANT: This version also requires a different version of WinIPAC for configuration.
+This version does not support Xinput.
+Unlike the Multi-Mode, this version automatically allocates each of the 2 game controllers on the respective side of the board so WinIPAC does not refer to player numbers, these are defined by the board markings. I-PAC 4 only supports 2 game controllers.

--- a/README.md
+++ b/README.md
@@ -23,11 +23,15 @@ This utility requires folder permission changes to the usb device directories be
 #### Building Utility:
 To build this project, at the base directory run the following commands
 * ./autogen.sh
-* ./configure
+* ./configure --disable-shared
 * make
 
 If you need extra debug statements for the IPac boards then run the following
 * ./configure CFLAGS='-DDEBUG'
+* make
+
+If you need libraries for your own programs then configure with shared enabled
+* ./configure --enable-shared
 * make
 
 The executable will be in src/umtool directory and named umtool.

--- a/README.md
+++ b/README.md
@@ -37,5 +37,11 @@ If you need libraries for your own programs then configure with shared enabled
 The executable will be in src/umtool directory and named umtool.
 * ./umtool ipac2.json
 
+UMTool may also be installed system wide (Tested on Debian 11 Bullseye)
+* sudo make install
+
+Update your shared libraries if using --enable-shared when compiling
+* sudo /sbin/ldconfig -v
+
 #### Donations:
 <a href='https://paypal.me/snowywhitewater?locale.x=en_US'>Click here to lend your support through PayPal!</a>

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.59)
-AC_INIT(Ultimarc-linux, 1.1)
+AC_INIT(Ultimarc-linux, 1.2)
 
 AC_CANONICAL_HOST
 AM_INIT_AUTOMAKE()
@@ -39,7 +39,7 @@ CPPFLAGS="-I$KERNEL_HEADERS_DIR/include"
 AX_PKG_CHECK_MODULES([JSON], [], [json-c >= 0.11])
 AX_PKG_CHECK_MODULES([LIBUSB], [], [libusb-1.0 >= 1.0.18])
 
-AC_SUBST([ULTIMARC_LIB_VERSION], [1.1])
+AC_SUBST([ULTIMARC_LIB_VERSION], [1.2])
 
 AC_CONFIG_FILES([Makefile
 		 src/libs/Makefile

--- a/scripts/aimtrak_readme
+++ b/scripts/aimtrak_readme
@@ -4,7 +4,7 @@ Emulators
 1 Mame by MameDev.org
 1.1 Using python script
 
-A script has been created to setup the files required to have AimTrak run.  This is a python3 script and follows the actions stated in the sections below.
+A script has been created to setup the files required to have AimTrak run.  This is a python 3.6 script and follows the actions stated in the sections below.
 To excute the file do the following;
 python aimtrak_setup.py -s
 

--- a/ultimarc.spec
+++ b/ultimarc.spec
@@ -3,7 +3,7 @@
 
 %define name ultimarc
 %define major 1
-%define minor 1
+%define minor 2
 %define release 14
 %define version %{major}.%{minor}
 


### PR DESCRIPTION
Apparently the default for ./configure is --enable-shared though this may be system dependent or change upstream in the future.
The most common usage is a single binary for the Linux UMTool user to run and the the build should reflect this.
3rd party programmers may still build libraries the same way or specify the --enable-shared flag.